### PR TITLE
Sets assembly page in grid

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,9 +1,12 @@
-export interface AssemblySummary {
+export interface Assembly {
     id: number,
-    period: {
+    period?: {
         from?: string,
         to?: string
     },
+}
+
+export interface AssemblyStatistics extends Assembly{
     division: {
         majority?: {
             id?: number,
@@ -18,6 +21,55 @@ export interface AssemblySummary {
     }
 }
 
+export interface AssemblySummary {
+    parties?: {
+        party: Party,
+        time: number
+    }[],
+    bills?: {
+        count: number,
+        status: string
+    }[],
+    governmentBills?: {
+        count: number,
+        status: string
+    }[],
+    types?: {
+        count: number,
+        type: string,
+        typeName: string,
+        typeSubName: string
+    }[],
+    votes?: {
+        count: number,
+        date: string
+    }[],
+    speeches?: {
+        count: number,
+        date: string
+    }[],
+    election?: {
+        id: number,
+        date: string,
+        title: string,
+        description: string
+    },
+    electionResults?: {
+        party: Party,
+        results: {
+            seats: number,
+            result: number
+        }
+    }[]
+}
+
+export interface AssemblyCategorySummary {
+    id: number
+    superCategoryId: number
+    title: string
+    count: number
+}
+
 export interface Picture {
     templateSrc: string
 }
@@ -28,10 +80,13 @@ export interface Party {
     color: string
 }
 
-export interface Congressman {
+export interface Person {
     id: number
     name: string
     avatar: Picture
+}
+
+export interface Congressman extends Person{
     party: Party
 }
 
@@ -42,35 +97,21 @@ export interface DocumentVote {
     congressman: Congressman
 }
 
-export interface AssemblyIssue {
-    id: number
-    assembly?: {id: number}
-    category?: string
-    name: string
-    subName?: string
-    type?: string
-    typeName: string
-    typeSubName?: string
-    status: string
-    question?: string
-    goal?: string
-    date: string
+export interface Issue {
+    id?: number,
+    assembly?: Assembly,
+    category?: string,
+    name?: string,
+    subName?: string,
+    type?: string,
+    typeName?: string,
+    typeSubName?: string,
+    status?: string,
+    goal?: string,
+    proponentsCount?: number,
+    proponents?: Congressman[]
 }
 
-export interface AssemblyCategorySummary {
-    id: number
-    superCategoryId: number
-    title: string
-    count: number
-}
-
-
-declare var __IMAGE_SERVER__: string;
-declare var __GRAPHQL_SERVER__: string;
-
-// declare const __IMAGE_SERVER__: string;
-// declare const __GRAPHQL_SERVER__: string;
-// declare const __APOLLO_STATE__: string;
 
 declare global {
     interface Window {

--- a/src/client/_config.scss
+++ b/src/client/_config.scss
@@ -8,7 +8,7 @@
     border-radius: 5px 5px 0 0;
 }
 
-@mixin shadow {
+@mixin shadow ($x: 0, $y: 10px, $blur: 50px) {
     box-shadow: 0 10px 50px rgba(0, 0, 0, 0.1);
 }
 

--- a/src/client/components/Assemblies/index.ts
+++ b/src/client/components/Assemblies/index.ts
@@ -1,26 +1,6 @@
 import {graphql, compose, gql} from 'react-apollo';
 import Assemblies from './Assemblies';
-import {AssemblySummary} from '../../../../@types';
-
-// type AssemblySummary = {
-//     id: number,
-//     period: {
-//         from?: string,
-//         to?: string
-//     },
-//     division: {
-//         majority?: {
-//             id?: number,
-//             name?: string,
-//             color?: string
-//         }[],
-//         minority: {
-//             id?: number,
-//             name?: string,
-//             color?: string
-//         }[]
-//     }
-// }
+import {AssemblyStatistics} from '../../../../@types';
 
 const assembliesQuery = gql`
     query {
@@ -37,7 +17,7 @@ const assembliesQuery = gql`
 
 export default compose<any>( //@todo `any`
     graphql(assembliesQuery, {
-        props: (all: {data?: {loading: boolean, Assemblies: AssemblySummary}}) => ({
+        props: (all: {data?: {loading: boolean, Assemblies: AssemblyStatistics}}) => ({
             assemblies: all.data.loading === false ? all.data.Assemblies : undefined,
             loading: all.data.loading,
         }),

--- a/src/client/components/AssemblyHeader/AssemblyHeader.tsx
+++ b/src/client/components/AssemblyHeader/AssemblyHeader.tsx
@@ -55,20 +55,16 @@ export default class AssemblyHeader extends React.Component<AssemblyHeaderProps,
                 <div className="assembly-header__parties">
                     <ul className="assembly-header__party-list">
                         {this.props.assembly.division.majority.map(party => (
-                            <li
-                                key={`party-${party.id}`}
-                                className="assembly-header__party-list-item"
-                            >
+                            <li key={`party-${party.id}`}
+                                className="assembly-header__party-list-item">
                                 <Badge title={party.name} color={party.color} />
                             </li>
                         ))}
                     </ul>
                     <ul className="assembly-header__party-list">
                         {this.props.assembly.division.minority.map(party => (
-                            <li
-                                key={`party-${party.id}`}
-                                className="assembly-header__party-list-item"
-                            >
+                            <li key={`party-${party.id}`}
+                                className="assembly-header__party-list-item">
                                 <Badge title={party.name} color={party.color} />
                             </li>
                         ))}

--- a/src/client/components/AssemblyHeader/index.scss
+++ b/src/client/components/AssemblyHeader/index.scss
@@ -3,6 +3,8 @@
 .assembly-header {
     display: flex;
     padding: map_get($space, xl) 0;
+    max-width: 1024px;
+    margin: auto;
 }
 
 .assembly-header__headline {

--- a/src/client/components/SearchSpeech/index.tsx
+++ b/src/client/components/SearchSpeech/index.tsx
@@ -5,15 +5,17 @@ import { Redirect } from "react-router-dom";
 import { OptionsWithKeyBinding } from "../../elements/Form";
 import { speechSearchAction, speechSearchClearAction } from "./redux";
 import { SpeechSearchResult } from "../../elements/SearchResult";
+import {
+    Assembly as AssemblyType,
+    Congressman as CongressmanType
+} from '../../../../@types'
 
 type SearchSpeechProps = {
     assembly?: number,
     issue?: number,
     result?: {
         id?: string,
-        assembly?: {
-            id?: number
-        },
+        assembly: AssemblyType,
         issue?: {
             id?: number
         },
@@ -25,18 +27,7 @@ type SearchSpeechProps = {
         iteration?: string,
         type?: string,
         congressmanType?: string,
-        congressman?: {
-            id?: number,
-            name?: string,
-            avatar?: {
-                templateSrc?: string
-            },
-            party?: {
-                id?: number,
-                name?: string,
-                color?: string
-            }
-        }
+        congressman: CongressmanType
     }[],
     isSearching?: boolean,
     onSearch?: (...args: any[]) => any,

--- a/src/client/elements/Badge/index.scss
+++ b/src/client/elements/Badge/index.scss
@@ -2,6 +2,7 @@
     width: 32px;
     height: 32px;
     border-radius: 50%;
+    display: inline-block;
 }
 
 .badge--xs {

--- a/src/client/elements/Congressman/index.tsx
+++ b/src/client/elements/Congressman/index.tsx
@@ -2,21 +2,12 @@ import * as React from "react";
 import Badge from "../Badge";
 import Avatar from "../Avatar";
 import { H3 } from "../Headline";
+import {Person as PersonType, Party as PartyType} from '../../../../@types'
 import './index.scss';
 
 type CongressmanProps = {
-    congressman?: {
-        id?: number,
-        name?: string,
-        avatar?: {
-            templateSrc?: string
-        }
-    },
-    party?: {
-        id?: number,
-        name?: string,
-        color?: string
-    }
+    congressman: PersonType,
+    party?: PartyType
 };
 
 export default class Congressman extends React.Component<CongressmanProps, {}> {

--- a/src/client/elements/IssueBadge/index.tsx
+++ b/src/client/elements/IssueBadge/index.tsx
@@ -5,33 +5,12 @@ import SimpleBillProgress from "../SimpleBillProgress";
 import SimpleRequestProgress from "../SimpleRequestProgress";
 import Badge from "../Badge";
 import Congressman from "../Congressman";
+import {Issue as IssueType, Congressman as CongressmanType} from '../../../../@types'
 import './index.scss';
 
 type ParliamentaryResolutionBadgeProps = {
-    issue?: {
-        id?: number,
-        assembly?: {
-            id?: number
-        },
-        name?: string,
-        subName?: string,
-        type?: string,
-        goal?: string,
-        typeName?: string,
-        proponentsCount?: number
-    },
-    congressman?: {
-        id?: number,
-        name?: string,
-        avatar?: {
-            templateSrc?: string
-        },
-        party?: {
-            id?: number,
-            name?: string,
-            color?: string
-        }
-    }
+    issue: IssueType,
+    congressman: CongressmanType
 };
 
 export class ParliamentaryResolutionBadge extends React.Component<ParliamentaryResolutionBadgeProps, {}> {
@@ -109,30 +88,8 @@ export class ParliamentaryResolutionBadge extends React.Component<ParliamentaryR
 }
 
 type RequestForReportBadgeProps = {
-    issue?: {
-        id?: number,
-        assembly?: {
-            id?: number
-        },
-        name?: string,
-        subName?: string,
-        type?: string,
-        goal?: string,
-        typeName?: string,
-        proponentsCount?: number
-    },
-    congressman?: {
-        id?: number,
-        name?: string,
-        avatar?: {
-            templateSrc?: string
-        },
-        party?: {
-            id?: number,
-            name?: string,
-            color?: string
-        }
-    }
+    issue: IssueType,
+    congressman: CongressmanType
 };
 
 export class RequestForReportBadge extends React.Component<RequestForReportBadgeProps, {}> {
@@ -210,30 +167,8 @@ export class RequestForReportBadge extends React.Component<RequestForReportBadge
 }
 
 type ReportBadgeProps = {
-    issue?: {
-        id?: number,
-        assembly?: {
-            id?: number
-        },
-        name?: string,
-        subName?: string,
-        type?: string,
-        goal?: string,
-        typeName?: string,
-        proponentsCount?: number
-    },
-    congressman?: {
-        id?: number,
-        name?: string,
-        avatar?: {
-            templateSrc?: string
-        },
-        party?: {
-            id?: number,
-            name?: string,
-            color?: string
-        }
-    }
+    issue: IssueType,
+    congressman: CongressmanType
 };
 
 export class ReportBadge extends React.Component<ReportBadgeProps, {}> {
@@ -311,30 +246,8 @@ export class ReportBadge extends React.Component<ReportBadgeProps, {}> {
 }
 
 type MeetingPostponementBadgeProps = {
-    issue?: {
-        id?: number,
-        assembly?: {
-            id?: number
-        },
-        name?: string,
-        subName?: string,
-        type?: string,
-        goal?: string,
-        typeName?: string,
-        proponentsCount?: number
-    },
-    congressman?: {
-        id?: number,
-        name?: string,
-        avatar?: {
-            templateSrc?: string
-        },
-        party?: {
-            id?: number,
-            name?: string,
-            color?: string
-        }
-    }
+    issue: IssueType,
+    congressman: CongressmanType
 };
 
 export class MeetingPostponementBadge extends React.Component<MeetingPostponementBadgeProps, {}> {
@@ -402,31 +315,8 @@ export class MeetingPostponementBadge extends React.Component<MeetingPostponemen
 }
 
 type BillBadgeProps = {
-    issue?: {
-        id?: number,
-        assembly?: {
-            id?: number
-        },
-        name?: string,
-        subName?: string,
-        status?: string,
-        type?: string,
-        goal?: string,
-        typeName?: string,
-        proponentsCount?: number
-    },
-    congressman?: {
-        id?: number,
-        name?: string,
-        avatar?: {
-            templateSrc?: string
-        },
-        party?: {
-            id?: number,
-            name?: string,
-            color?: string
-        }
-    }
+    issue: IssueType,
+    congressman: CongressmanType
 };
 
 export class BillBadge extends React.Component<BillBadgeProps, {}> {
@@ -524,31 +414,8 @@ export class BillBadge extends React.Component<BillBadgeProps, {}> {
 }
 
 type InquiryBadgeProps = {
-    issue?: {
-        id?: number,
-        assembly?: {
-            id?: number
-        },
-        status?: string
-        name?: string,
-        subName?: string,
-        type?: string,
-        goal?: string,
-        typeName?: string,
-        proponentsCount?: number
-    },
-    congressman?: {
-        id?: number,
-        name?: string,
-        avatar?: {
-            templateSrc?: string
-        },
-        party?: {
-            id?: number,
-            name?: string,
-            color?: string
-        }
-    }
+    issue: IssueType,
+    congressman: CongressmanType
 };
 
 export class InquiryBadge extends React.Component<InquiryBadgeProps, {}> {
@@ -632,31 +499,8 @@ export class InquiryBadge extends React.Component<InquiryBadgeProps, {}> {
 }
 
 type WrittenInquiryBadgeProps = {
-    issue?: {
-        id?: number,
-        assembly?: {
-            id?: number
-        },
-        name?: string,
-        status?: string,
-        subName?: string,
-        type?: string,
-        goal?: string,
-        typeName?: string,
-        proponentsCount?: number
-    },
-    congressman?: {
-        id?: number,
-        name?: string,
-        avatar?: {
-            templateSrc?: string
-        },
-        party?: {
-            id?: number,
-            name?: string,
-            color?: string
-        }
-    }
+    issue: IssueType,
+    congressman: CongressmanType
 };
 
 export class WrittenInquiryBadge extends React.Component<WrittenInquiryBadgeProps, {}> {
@@ -740,17 +584,7 @@ export class WrittenInquiryBadge extends React.Component<WrittenInquiryBadgeProp
 }
 
 type OpinionBadgeProps = {
-    issue?: {
-        id?: number,
-        assembly?: {
-            id?: number
-        },
-        name?: string,
-        subName?: string,
-        type?: string,
-        goal?: string,
-        typeName?: string
-    }
+    issue: IssueType,
 };
 
 export class OpinionBadge extends React.Component<OpinionBadgeProps, {}> {
@@ -796,30 +630,8 @@ export class OpinionBadge extends React.Component<OpinionBadgeProps, {}> {
 }
 
 type IssueBadgeProps = {
-    issue?: {
-        id?: number,
-        assembly?: {
-            id?: number
-        },
-        name?: string,
-        subName?: string,
-        type?: string,
-        goal?: string,
-        typeName?: string,
-        proponentsCount?: number
-    },
-    congressman?: {
-        id?: number,
-        name?: string,
-        avatar?: {
-            templateSrc?: string
-        },
-        party?: {
-            id?: number,
-            name?: string,
-            color?: string
-        }
-    }
+    issue: IssueType,
+    congressman: CongressmanType
 };
 
 export class IssueBadge extends React.Component<IssueBadgeProps, {}> {

--- a/src/client/elements/IssueTypeSummary/index.scss
+++ b/src/client/elements/IssueTypeSummary/index.scss
@@ -1,0 +1,28 @@
+@import '../../config';
+
+.issue-type-summary {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.issue-type-summary__caption {
+    text-align: left;
+}
+
+.issue-type-summary__head {
+    display: none;
+}
+
+.issue-type-summary__body {
+
+}
+
+.issue-type-summary__count {
+    text-align: right;
+    padding: 0 map_get($space, xs);
+}
+
+.issue-type-summary__title {
+    padding: 0 map_get($space, xs);
+    text-transform: capitalize;
+}

--- a/src/client/elements/IssueTypeSummary/index.tsx
+++ b/src/client/elements/IssueTypeSummary/index.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import {StatelessComponent} from 'react';
+import { Link } from "react-router-dom";
+import './index.scss';
+import {H2} from "../Headline";
+
+type Props = {
+    assembly: {
+        id?: number,
+        period?: {
+            from?: string,
+            to?: string
+        }
+    },
+    summary?: {
+        parties?: {
+            party?: {
+                id?: number,
+                name?: string,
+                color?: string
+            },
+            time?: number
+        }[],
+        bills?: {
+            count?: number,
+            status?: string
+        }[],
+        governmentBills?: {
+            count?: number,
+            status?: string
+        }[],
+        types?: {
+            count?: number,
+            type?: string,
+            typeName?: string,
+            typeSubName?: string
+        }[],
+        votes?: {
+            count?: number,
+            date?: string
+        }[],
+        speeches?: {
+            count?: number,
+            date?: string
+        }[],
+        election?: {
+            id?: number,
+            date?: string,
+            title?: string,
+            description?: string
+        },
+        electionResults?: {
+            party?: {
+                id?: number,
+                name?: string,
+                color?: string
+            },
+            results?: {
+                seats?: number,
+                result?: number
+            }
+        }[]
+    },
+}
+
+const Component: StatelessComponent<Props> = ({children, assembly, summary}) => (
+    <table className="issue-type-summary">
+        <caption className="issue-type-summary__caption">
+            <H2>Málstegundir</H2>
+        </caption>
+        <thead className="issue-type-summary__head">
+            <tr>
+                <td>Fjöldi</td>
+                {/*<td>Titill</td>*/}
+                <td>Undirtitill</td>
+            </tr>
+        </thead>
+        <tbody className="issue-type-summary__body">
+            {summary.types.map(type => (
+                <tr key={`type-${type.type}`}>
+                    <td className="issue-type-summary__count">
+                        {type.count}
+                    </td>
+                    {/*<td>{type.typeName}</td>*/}
+                    <td className="issue-type-summary__title">
+                        <Link to={`/loggjafarthing/${assembly.id}/thingmal?tegund=${type.type}`}>
+                            {type.typeSubName}
+                        </Link>
+                    </td>
+                </tr>
+            ))}
+        </tbody>
+        <tfoot>
+            <tr>
+                <td className="issue-type-summary__count">{summary.types.reduce((prev, current) => prev + current.count, 0)}</td>
+                <td className="issue-type-summary__title" >—</td>
+            </tr>
+        </tfoot>
+    </table>
+);
+
+export default Component;

--- a/src/client/elements/PartyPieChart/index.tsx
+++ b/src/client/elements/PartyPieChart/index.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react';
 import { pie, arc } from "d3-shape";
+import {Party as PartyType} from '../../../../@types'
 import './index.scss';
 
 type PartyPieChartProps = {
-    source?: {
-        party?: {
-            id?: number,
-            name?: string,
-            color?: string
-        },
+    source: {
+        party: PartyType,
         value?: number
     }[],
     formatValue?: (...args: any[]) => any

--- a/src/client/elements/PartySpeechSummary/index.scss
+++ b/src/client/elements/PartySpeechSummary/index.scss
@@ -1,0 +1,31 @@
+@import '../../config';
+
+.party-speech-summary {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.party-speech-summary__caption {
+    text-align: left;
+}
+
+.party-speech-summary__head {
+    display: none;
+}
+
+.party-speech-summary__body {
+
+}
+
+.party-speech-summary__time {
+    text-align: right;
+    padding: 0 map_get($space, xs);
+}
+
+.party-speech-summary__badge {
+    text-align: center;
+}
+
+.party-speech-summary__title {
+    padding: 0 map_get($space, xs);
+}

--- a/src/client/elements/PartySpeechSummary/index.tsx
+++ b/src/client/elements/PartySpeechSummary/index.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import {StatelessComponent} from 'react';
+import Badge from "../Badge";
+import {Party as PartyType} from '../../../../@types'
+import './index.scss';
+
+type Props = {
+    parties: {
+        party: PartyType,
+        time?: number
+    }[]
+}
+
+const Component: StatelessComponent<Props> = ({children, parties}) => (
+    <table className="party-speech-summary">
+        <caption className="party-speech-summary__caption">
+            Ræðutími þingflokka i mínútum
+        </caption>
+        <thead className="party-speech-summary__head">
+            <tr>
+                <td>mínútur</td>
+                <td>flokkslitur</td>
+                <td>flokkur</td>
+        </tr>
+        </thead>
+        <tbody className="party-speech-summary__body">
+            {parties.map(obj => (
+                <tr key={`party-${obj.party.id}`}>
+                    <td className="party-speech-summary__time">{Math.floor(obj.time / 60)}</td>
+                    <td className="party-speech-summary__badge">
+                        <Badge color={obj.party.color}
+                            title={obj.party.name}
+                            variations={["sm"]}
+                        />
+                    </td>
+                    <td className="party-speech-summary__title">
+                        {obj.party.name}
+                    </td>
+                </tr>
+            ))}
+        </tbody>
+    </table>
+);
+
+export default Component;

--- a/src/client/elements/PieChart/index.scss
+++ b/src/client/elements/PieChart/index.scss
@@ -1,14 +1,60 @@
+@import "../../config";
 
-.party-pie-chart {
+.pie-chart {
+    display: inline-block;
     max-width: 100%;
     height: auto;
+    position: relative;
 }
 
-.party-pie-chart__arch {
+.pie-chart__arch {
     //ref
 }
 
-.party-pie-chart__path {
+.pie-chart__label {
+    @include shadow($blur: 5px);
+
+    padding: map_get($space, xxs);
+    position: absolute;
+    pointer-events: none;
+    background: white;
+    white-space: nowrap;
+
+}
+
+.pie-chart__path {
     stroke: white;
     stroke-width: 1px;
+}
+
+
+.pie-chart__path--unapproved {
+    fill: #bbbbbb;
+}
+.pie-chart__path--approved {
+    fill: #74bb72;
+}
+
+.pie-chart__path--iteration-one {
+    fill: yellow;
+}
+
+.pie-chart__path--iteration-two {
+    fill: orange;
+}
+
+.pie-chart__path--committee-one {
+    fill: #E68787;
+}
+
+.pie-chart__path--committee-two {
+    fill: #E68787;
+}
+
+.pie-chart__path--await-one {
+    fill: #E68787;
+}
+
+.pie-chart__path--await-two {
+    fill: #E68787;
 }

--- a/src/client/elements/SearchResult/SpeechSearchResult.tsx
+++ b/src/client/elements/SearchResult/SpeechSearchResult.tsx
@@ -3,6 +3,11 @@ import classVariations from "../../utils/classVariations";
 import SpeechCard from "../SpeechCard";
 import Congressman from "../Congressman";
 import { H4 } from "../Headline";
+import {
+    Congressman as CongressmanType,
+    Assembly as AssemblyType
+} from '../../../../@types'
+
 
 type IssueSearchResultProps = {
     onSelect?: (...args: any[]) => any,
@@ -10,9 +15,7 @@ type IssueSearchResultProps = {
     variations?: any[],
     value?: {
         id?: string,
-        assembly?: {
-            id?: number
-        },
+        assembly: AssemblyType,
         issue?: {
             id?: number
         },
@@ -24,18 +27,7 @@ type IssueSearchResultProps = {
         iteration?: string,
         type?: string,
         congressmanType?: string,
-        congressman?: {
-            id?: number,
-            name?: string,
-            avatar?: {
-                templateSrc?: string
-            },
-            party?: {
-                id?: number,
-                name?: string,
-                color?: string
-            }
-        }
+        congressman: CongressmanType
     }
 };
 
@@ -51,15 +43,12 @@ export default class IssueSearchResult extends React.Component<IssueSearchResult
             ? this.props.variations.concat(["active"])
             : this.props.variations;
         return (
-            <div
-                className={classVariations("options-list__item", variations)}
-                onClick={() => this.props.onSelect(this.props.value)}
-            >
+            <div className={classVariations("options-list__item", variations)}
+                onClick={() => this.props.onSelect(this.props.value)}>
                 <SpeechCard speech={this.props.value}>
                     <Congressman
                         congressman={this.props.value.congressman}
-                        party={this.props.value.congressman.party}
-                    >
+                        party={this.props.value.congressman.party}>
                         <H4>{this.props.value.congressmanType}</H4>
                     </Congressman>
                 </SpeechCard>

--- a/src/client/panels/Assembly/Assembly.tsx
+++ b/src/client/panels/Assembly/Assembly.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
-import { Fragment } from "react";
-import { Link } from "react-router-dom";
-import { Column, Row, Grid } from "../../elements/Grid";
-import { ISSUE_STATUS } from "../../utils/maps";
+import {Fragment} from "react";
+import {Link} from "react-router-dom";
+import {Column, Row} from "../../elements/Grid";
 import DateAndCountChart from "../../elements/DateAndCountChart";
 import PartyPieChart from "../../elements/PartyPieChart";
-import StatusPieChart from "../../elements/StatusPieChart";
 import SeatChart from "../../elements/SeatChart";
 import PieChart from "../../elements/PieChart";
 import Paper from "../../elements/Paper";
-import Badge from "../../elements/Badge";
 import Congressman from "../../elements/Congressman";
+import {H2} from "../../elements/Headline";
+import Section from "../../elements/Section";
+import IssueTypeSummary from '../../elements/IssueTypeSummary';
+import PartySpeechSummary from '../../elements/PartySpeechSummary';
+import {billsPerformance, reduceBillsByStatus, mapBillStatusToKey} from '../../utils/bills'
 import {
     BillBadge,
     InquiryBadge,
@@ -21,170 +23,39 @@ import {
     RequestForReportBadge,
     WrittenInquiryBadge
 } from "../../elements/IssueBadge";
-import { H2, H3 } from "../../elements/Headline";
-import Section from "../../elements/Section";
+import {
+    Assembly as AssemblyType,
+    Congressman as CongressmanType,
+    Issue as IssueType,
+    AssemblySummary as AssemblySummaryType
+} from '../../../../@types'
 import "./index.scss";
 
 type AssemblyProps = {
-    assembly?: {
-        id?: number,
-        period?: {
-            from?: string,
-            to?: string
-        }
-    },
-    summary?: {
-        parties?: {
-            party?: {
-                id?: number,
-                name?: string,
-                color?: string
-            },
-            time?: number
-        }[],
-        bills?: {
-            count?: number,
-            status?: string
-        }[],
-        governmentBills?: {
-            count?: number,
-            status?: string
-        }[],
-        types?: {
-            count?: number,
-            type?: string,
-            typeName?: string,
-            typeSubName?: string
-        }[],
-        votes?: {
-            count?: number,
-            date?: string
-        }[],
-        speeches?: {
-            count?: number,
-            date?: string
-        }[],
-        election?: {
-            id?: number,
-            date?: string,
-            title?: string,
-            description?: string
-        },
-        electionResults?: {
-            party?: {
-                id?: number,
-                name?: string,
-                color?: string
-            },
-            results?: {
-                seats?: number,
-                result?: number
-            }
-        }[]
-    },
-    speakMost?: {
-        congressman?: {
-            id?: number,
-            name?: string,
-            avatar?: {
-                templateSrc?: string
-            },
-            party?: {
-                id?: number,
-                name?: string,
-                color?: string
-            }
-        },
-        value?: number
+    assembly: AssemblyType,
+    summary: AssemblySummaryType,
+    speakMost: {
+        congressman: CongressmanType,
+        value: number
     }[],
-    speakLeast?: {
-        congressman?: {
-            id?: number,
-            name?: string,
-            avatar?: {
-                templateSrc?: string
-            },
-            party?: {
-                id?: number,
-                name?: string,
-                color?: string
-            }
-        },
-        value?: number
+    speakLeast: {
+        congressman: CongressmanType,
+        value: number
     }[],
-    questioner?: {
-        congressman?: {
-            id?: number,
-            name?: string,
-            avatar?: {
-                templateSrc?: string
-            },
-            party?: {
-                id?: number,
-                name?: string,
-                color?: string
-            }
-        },
-        value?: number
+    questioner: {
+        congressman?: CongressmanType,
+        value: number
     }[],
-    resolutionaries?: {
-        congressman?: {
-            id?: number,
-            name?: string,
-            avatar?: {
-                templateSrc?: string
-            },
-            party?: {
-                id?: number,
-                name?: string,
-                color?: string
-            }
-        },
-        value?: number
+    resolutionaries: {
+        congressman: CongressmanType,
+        value: number
     }[],
-    bills?: {
-        congressman?: {
-            id?: number,
-            name?: string,
-            avatar?: {
-                templateSrc?: string
-            },
-            party?: {
-                id?: number,
-                name?: string,
-                color?: string
-            }
-        },
-        value?: number
+    bills: {
+        congressman: CongressmanType,
+        value: number
     }[],
     issues?: {
-        issue?: {
-            id?: number,
-            assembly?: {
-                id?: number
-            },
-            category?: string,
-            name?: string,
-            subName?: string,
-            type?: string,
-            typeName?: string,
-            typeSubName?: string,
-            status?: string,
-            goal?: string,
-            proponentsCount?: number,
-            proponents?: {
-                id?: number,
-                name?: string,
-                avatar?: {
-                    templateSrc?: string
-                },
-                party?: {
-                    id?: number,
-                    name?: string,
-                    color?: string
-                }
-            }[]
-        },
+        issue?: IssueType,
         value?: number
     }[]
 };
@@ -221,635 +92,263 @@ export default class Assembly extends React.Component<AssemblyProps, {}> {
         bills: [],
         issues: []
     };
-    reduceBills(bills) {
-        return bills.reduce((accumulator, currentValue) => {
-            if (!accumulator.hasOwnProperty("unapproved")) {
-                accumulator.unapproved = 0;
-            }
-            if (currentValue.status === "Samþykkt sem lög frá Alþingi") {
-                accumulator.approved = currentValue.count;
-            } else {
-                accumulator.unapproved =
-                    accumulator.unapproved + currentValue.count;
-            }
-            return accumulator;
-        }, {});
-    }
-    billsPerformance(value) {
-        return Math.round(
-            (value.approved / (value.unapproved + value.approved)) * 100
-        );
-    }
+
     render() {
         return (
             <Fragment>
-                <Section>
-                    <Paper>
-                        <Grid>
+                <section className="assembly-page-grid">
+                    <article className="assembly-page-grid__header">
+                        <Paper>
                             <Row>
-                                <Column sm={2}>
-                                    <h2>{this.props.assembly.id}</h2>
-                                    <time>
-                                        {this.props.assembly.period.from}
-                                    </time>
-                                    <time>{this.props.assembly.period.to}</time>
+                                <Column>
+                                    <div>
+                                        <h2>Frumvörp</h2>
+                                        <PieChart source={Object.entries(reduceBillsByStatus(this.props.summary.bills)).map(([key, value]) => ({
+                                                value: Number(value),
+                                                key: String(key),
+                                            }))}
+                                        />
+                                        <h2>
+                                            {billsPerformance(reduceBillsByStatus(this.props.summary.bills))}%
+                                        </h2>
+                                        <h4>Frumvörp samþykkt</h4>
+                                    </div>
                                 </Column>
-                                <Column sm={10}>
-                                    <Row>
-                                        <Column>
-                                            <div>
-                                                <h2>Frumvörp</h2>
-                                                <PieChart
-                                                    source={Object.entries(
-                                                        this.reduceBills(this.props.summary.bills)
-                                                    ).map(item => ({
-                                                        value: Number(item[1]),
-                                                        key: String(item[0]),
-                                                    }))}
-                                                />
+                                <Column>
+                                    <h2>Staða frumvarpa</h2>
+                                    <PieChart formatValue={(label, value, total) => `${label} (${Math.round(value / total * 100)}%)`}
+                                              source={this.props.summary.bills.map(mapBillStatusToKey).map(bill => ({
+                                                  value: Number(bill.count),
+                                                  key: String(bill.key),
+                                                  label: bill.label,
+                                              }))}
+                                    />
+                                </Column>
+                                <Column>
+                                    <div>
+                                        <h2>Stjórnarfrumvörp</h2>
+                                        <PieChart source={Object.entries(reduceBillsByStatus(this.props.summary.governmentBills)).map(([key, value]) => ({
+                                                value: Number(value),
+                                                key: String(key)
+                                            }))}
+                                        />
+                                        <h2>
+                                            {billsPerformance(reduceBillsByStatus(this.props.summary.governmentBills))}%
+                                        </h2>
+                                        <h4>
+                                            Stjórnarfrumvörp samþykkt
+                                        </h4>
+                                    </div>
+                                </Column>
 
-                                                <h2>
-                                                    {this.billsPerformance(
-                                                        this.reduceBills(
-                                                            this.props.summary
-                                                                .bills
-                                                        )
-                                                    )}%
-                                                </h2>
-                                                <h4>Frumvörp samþykkt</h4>
-                                            </div>
-                                        </Column>
-                                        <Column>
-                                            <div>
-                                                <h2>Stjórnarfrumvörp</h2>
-                                                <PieChart
-                                                    source={Object.entries(
-                                                        this.reduceBills(this.props.summary.governmentBills)
-                                                    ).map(item => ({
-                                                        value: Number(item[1]),
-                                                        key: String(item[0])
-                                                    }))}
-                                                />
-                                                <h2>
-                                                    {this.billsPerformance(
-                                                        this.reduceBills(
-                                                            this.props.summary
-                                                                .governmentBills
-                                                        )
-                                                    )}%
-                                                </h2>
-                                                <h4>
-                                                    Stjórnarfrumvörp samþykkt
-                                                </h4>
-                                            </div>
-                                        </Column>
-                                    </Row>
-                                    <Row>
-                                        <Column>
-                                            <table>
-                                                <caption>
-                                                    <h2>Issues by type</h2>
-                                                </caption>
-                                                <thead>
-                                                    <tr>
-                                                        <td>Fjöldi</td>
-                                                        <td>Titill</td>
-                                                        <td>Undirtitill</td>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    {this.props.summary.types.map(
-                                                        type => (
-                                                            <tr
-                                                                key={`type-${
-                                                                    type.type
-                                                                }`}
-                                                            >
-                                                                <td>
-                                                                    {type.count}
-                                                                </td>
-                                                                <td>
-                                                                    {
-                                                                        type.typeName
-                                                                    }
-                                                                </td>
-                                                                <td>
-                                                                    <Link
-                                                                        to={`/loggjafarthing/${
-                                                                            this
-                                                                                .props
-                                                                                .assembly
-                                                                                .id
-                                                                        }/thingmal?tegund=${
-                                                                            type.type
-                                                                        }`}
-                                                                    >
-                                                                        {
-                                                                            type.typeSubName
-                                                                        }
-                                                                    </Link>
-                                                                </td>
-                                                            </tr>
-                                                        )
-                                                    )}
-                                                </tbody>
-                                            </table>
-                                        </Column>
-                                    </Row>
+                                <Column>
+                                    <p>Medalaldur </p>
+                                    <p>kynjahlutfall </p>
                                 </Column>
                             </Row>
-                        </Grid>
+                        </Paper>
+                    </article>
+                    <article className="assembly-page-grid__popular">
+                        <ul className="assembly-issues-panel__list">
+                            {this.props.issues.map(
+                                issue =>
+                                    ({
+                                        a: (
+                                            <li key={`issue-${issue.issue.id}`}
+                                                className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm">
+                                                <ParliamentaryResolutionBadge issue={issue.issue}
+                                                    congressman={issue.issue.proponents.reduce((a, b) => b, undefined)}>
+                                                    {issue.value}
+                                                </ParliamentaryResolutionBadge>
+                                            </li>
+                                        ),
+                                        b: (
+                                            <li key={`issue-${issue.issue.id}`}
+                                                className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm">
+                                                <RequestForReportBadge issue={issue.issue}
+                                                    congressman={issue.issue.proponents.reduce((a, b) => b, undefined)}>
+                                                    {issue.value}
+                                                </RequestForReportBadge>
+                                            </li>
+                                        ),
+                                        f: (
+                                            <li key={`issue-${issue.issue.id}`}
+                                                className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm">
+                                                <MeetingPostponementBadge issue={issue.issue}
+                                                    congressman={issue.issue.proponents.reduce((a, b) => b, undefined)}>
+                                                    {issue.value}
+                                                </MeetingPostponementBadge>
+                                            </li>
+                                        ),
+                                        l: (
+                                            <li key={`issue-${issue.issue.id}`}
+                                                className="assembly-issues-panel__list-item assembly-issues-panel__list-item--lg">
+                                                <BillBadge issue={issue.issue}
+                                                    congressman={issue.issue.proponents.reduce((a, b) => b, undefined)}>
+                                                    {issue.value}
+                                                </BillBadge>
+                                            </li>
+                                        ),
+                                        m: (
+                                            <li key={`issue-${issue.issue.id}`}
+                                                className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm">
+                                                <InquiryBadge issue={issue.issue}
+                                                    congressman={issue.issue.proponents.reduce((a, b) => b, undefined)}>
+                                                    {issue.value}
+                                                </InquiryBadge>
+                                            </li>
+                                        ),
+                                        n: (
+                                            <li key={`issue-${issue.issue.id}`}
+                                                className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm">
+                                                <OpinionBadge issue={issue.issue}>
+                                                    {issue.value}
+                                                </OpinionBadge>
+                                            </li>
+                                        ),
+                                        q: (
+                                            <li key={`issue-${issue.issue.id}`}
+                                                className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm">
+                                                <WrittenInquiryBadge issue={issue.issue}
+                                                    congressman={issue.issue.proponents.reduce((a, b) => b, undefined)}>
+                                                    {issue.value}
+                                                </WrittenInquiryBadge>
+                                            </li>
+                                        ),
+                                        s: (
+                                            <li key={`issue-${issue.issue.id}`}
+                                                className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm">
+                                                <ReportBadge issue={issue.issue}
+                                                    congressman={issue.issue.proponents.reduce((a, b) => b, undefined)}>
+                                                    {issue.value}
+                                                </ReportBadge>
+                                            </li>
+                                        )
+                                    }[issue.issue.type])
+                            )}
+                        </ul>
+                    </article>
+                    <article className="assembly-page-grid__types">
+                        <IssueTypeSummary assembly={this.props.assembly} summary={this.props.summary} />
+                    </article>
+                    <article className="assembly-page-grid__speeches">
+                        <H2>Ræðutímar</H2>
+                        <PieChart source={this.props.summary.parties.map(party => ({
+                                value: party.time,
+                                key: party.party.name,
+                                label: party.party.name,
+                                color: `#${party.party.color}`
+                            }))}
+                            formatValue={(label, value, total) => `${label} (${Math.round(value / total * 100)}%)`}
+                        />
+                        <PartySpeechSummary parties={this.props.summary.parties} />
+                    </article>
+                    <article className="assembly-page-grid__talk-max">
+                        <H2>Þessi töludu mest</H2>
+                        <ul>
+                            {this.props.speakMost.map(data => (
+                                <li key={`congressman-speak-${data.congressman.id}`}>
+                                    <Link to={`/loggjafarthing/${this.props.assembly.id}/thingmenn/${data.congressman.id}`}>
+                                        <Congressman congressman={data.congressman} party={data.congressman.party}>
+                                            {data.value}
+                                        </Congressman>
+                                    </Link>
+                                </li>
+                            ))}
+                        </ul>
+                    </article>
+                    <article className="assembly-page-grid__talk-min">
+                        <H2>Þessi töludu minnst</H2>
+                        <ul>
+                            {this.props.speakLeast.map(data => (
+                                <li key={`congressman-speak-${data.congressman.id}`}>
+                                    <Link to={`/loggjafarthing/${this.props.assembly.id}/thingmenn/${data.congressman.id}`}>
+                                        <Congressman congressman={data.congressman} party={data.congressman.party}>
+                                            {data.value}
+                                        </Congressman>
+                                    </Link>
+                                </li>
+                            ))}
+                        </ul>
+                    </article>
+                    <article className="assembly-page-grid__questions">
+                        <H2>Þessi spurðu mest</H2>
+                        <ul>
+                            {this.props.questioner.map(data => (
+                                <li key={`congressman-questioner-${data.congressman.id}`}>
+                                    <Link to={`/loggjafarthing/${this.props.assembly.id}/thingmenn/${data.congressman.id}`}>
+                                        <Congressman congressman={data.congressman} party={data.congressman.party}>
+                                            {data.value}
+                                        </Congressman>
+                                    </Link>
+                                </li>
+                            ))}
+                        </ul>
+                    </article>
+                    <article className="assembly-page-grid__resolution">
+                        <H2>Tillögur til þingsályktana</H2>
+                        <ul>
+                            {this.props.resolutionaries.map(data => (
+                                <li key={`congressman-resolutionaries-${data.congressman.id}`}>
+                                    <Link to={`/loggjafarthing/${this.props.assembly.id}/thingmenn/${data.congressman.id}`}>
+                                        <Congressman congressman={data.congressman} party={data.congressman.party}>
+                                            {data.value}
+                                        </Congressman>
+                                    </Link>
+                                </li>
+                            ))}
+                        </ul>
+                    </article>
+                    <article className="assembly-page-grid__law">
+                        <H2>Frumvörp til laga</H2>
+                        <ul>
+                            {this.props.bills.map(data => (
+                                <li key={`congressman-bills-${data.congressman.id}`}>
+                                    <Link to={`/loggjafarthing/${this.props.assembly.id}/thingmenn/${data.congressman.id}`}>
+                                        <Congressman congressman={data.congressman} party={data.congressman.party}>
+                                            {data.value}
+                                        </Congressman>
+                                    </Link>
+                                </li>
+                            ))}
+                        </ul>
+                    </article>
+                    <article className="assembly-page-grid__election">
+                        <H2>Úrslit kosninga</H2>
+                        <PartyPieChart formatValue={v => ` ${v}%`}
+                            source={this.props.summary.electionResults.map(
+                                item => ({
+                                    party: item.party,
+                                    value: item.results.result
+                                })
+                            )}
+                        />
+                        <div>{this.props.summary.election && this.props.summary.election.title}</div>
+                        <div>{this.props.summary.election && this.props.summary.election.date}</div>
+                        <div>{this.props.summary.election && this.props.summary.election.description}</div>
+                    </article>
+                    <article className="assembly-page-grid__seating">
+                        <H2>Sætaskipan</H2>
+                        <SeatChart source={this.props.summary.electionResults.map(item => ({
+                                party: item.party,
+                                value: item.results.seats
+                            }))}
+                        />
+                    </article>
+                </section>
+                <Section>
+                    <Paper>
+                        <Row>
+                            <Column>
+                                <h2>Votes</h2>
+                                <DateAndCountChart source={this.props.summary.votes}/>
+                            </Column>
+                            <Column>
+                                <h2>Speeches</h2>
+                                <DateAndCountChart source={this.props.summary.speeches}/>
+                            </Column>
+                        </Row>
                     </Paper>
-                </Section>
-                <Section>
-                    <Grid>
-                        <Row>
-                            <Column sm={4}>
-                                <Row>
-                                    <Column>
-                                        <H2>Ræðutímar þingflokka</H2>
-                                        <PartyPieChart
-                                            formatValue={v =>
-                                                ` ${Math.floor(v / 60)} min`
-                                            }
-                                            source={this.props.summary.parties.map(
-                                                item => ({
-                                                    party: item.party,
-                                                    value: item.time
-                                                })
-                                            )}
-                                        />
-                                    </Column>
-                                </Row>
-                                <Row>
-                                    <Column>
-                                        <table>
-                                            <caption>
-                                                Ræðutími þingflokka i mínútum
-                                            </caption>
-                                            <thead>
-                                                <tr>
-                                                    <td>&nbsp;</td>
-                                                    <td>party</td>
-                                                    <td>time</td>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                {this.props.summary.parties.map(
-                                                    (obj, i) => (
-                                                        <tr
-                                                            key={`party-${
-                                                                obj.party.id
-                                                            }`}
-                                                        >
-                                                            <td>
-                                                                <Badge
-                                                                    color={
-                                                                        obj
-                                                                            .party
-                                                                            .color
-                                                                    }
-                                                                    title={
-                                                                        obj
-                                                                            .party
-                                                                            .name
-                                                                    }
-                                                                    variations={[
-                                                                        "sm"
-                                                                    ]}
-                                                                />
-                                                            </td>
-                                                            <td>
-                                                                {obj.party.name}
-                                                            </td>
-                                                            <td>
-                                                                {Math.floor(
-                                                                    obj.time /
-                                                                        60
-                                                                )}{" "}
-                                                                mínútur
-                                                            </td>
-                                                        </tr>
-                                                    )
-                                                )}
-                                            </tbody>
-                                        </table>
-                                    </Column>
-                                </Row>
-                            </Column>
-                            <Column sm={8}>
-                                <H2>Þessi mál voru mest rædd</H2>
-                                <ul className="assembly-issues-panel__list">
-                                    {this.props.issues.map(
-                                        issue =>
-                                            ({
-                                                a: (
-                                                    <li
-                                                        key={`issue-${
-                                                            issue.issue.id
-                                                        }`}
-                                                        className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm"
-                                                    >
-                                                        <ParliamentaryResolutionBadge
-                                                            issue={issue.issue}
-                                                            congressman={issue.issue.proponents.reduce(
-                                                                (a, b) => b,
-                                                                undefined
-                                                            )}
-                                                        >
-                                                            {issue.value}
-                                                        </ParliamentaryResolutionBadge>
-                                                    </li>
-                                                ),
-                                                b: (
-                                                    <li
-                                                        key={`issue-${
-                                                            issue.issue.id
-                                                        }`}
-                                                        className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm"
-                                                    >
-                                                        <RequestForReportBadge
-                                                            issue={issue.issue}
-                                                            congressman={issue.issue.proponents.reduce(
-                                                                (a, b) => b,
-                                                                undefined
-                                                            )}
-                                                        >
-                                                            {issue.value}
-                                                        </RequestForReportBadge>
-                                                    </li>
-                                                ),
-                                                f: (
-                                                    <li
-                                                        key={`issue-${
-                                                            issue.issue.id
-                                                        }`}
-                                                        className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm"
-                                                    >
-                                                        <MeetingPostponementBadge
-                                                            issue={issue.issue}
-                                                            congressman={issue.issue.proponents.reduce(
-                                                                (a, b) => b,
-                                                                undefined
-                                                            )}
-                                                        >
-                                                            {issue.value}
-                                                        </MeetingPostponementBadge>
-                                                    </li>
-                                                ),
-                                                l: (
-                                                    <li
-                                                        key={`issue-${
-                                                            issue.issue.id
-                                                        }`}
-                                                        className="assembly-issues-panel__list-item assembly-issues-panel__list-item--lg"
-                                                    >
-                                                        <BillBadge
-                                                            issue={issue.issue}
-                                                            congressman={issue.issue.proponents.reduce(
-                                                                (a, b) => b,
-                                                                undefined
-                                                            )}
-                                                        >
-                                                            {issue.value}
-                                                        </BillBadge>
-                                                    </li>
-                                                ),
-                                                m: (
-                                                    <li
-                                                        key={`issue-${
-                                                            issue.issue.id
-                                                        }`}
-                                                        className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm"
-                                                    >
-                                                        <InquiryBadge
-                                                            issue={issue.issue}
-                                                            congressman={issue.issue.proponents.reduce(
-                                                                (a, b) => b,
-                                                                undefined
-                                                            )}
-                                                        >
-                                                            {issue.value}
-                                                        </InquiryBadge>
-                                                    </li>
-                                                ),
-                                                n: (
-                                                    <li
-                                                        key={`issue-${
-                                                            issue.issue.id
-                                                        }`}
-                                                        className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm"
-                                                    >
-                                                        <OpinionBadge
-                                                            issue={issue.issue}
-                                                        >
-                                                            {issue.value}
-                                                        </OpinionBadge>
-                                                    </li>
-                                                ),
-                                                q: (
-                                                    <li
-                                                        key={`issue-${
-                                                            issue.issue.id
-                                                        }`}
-                                                        className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm"
-                                                    >
-                                                        <WrittenInquiryBadge
-                                                            issue={issue.issue}
-                                                            congressman={issue.issue.proponents.reduce(
-                                                                (a, b) => b,
-                                                                undefined
-                                                            )}
-                                                        >
-                                                            {issue.value}
-                                                        </WrittenInquiryBadge>
-                                                    </li>
-                                                ),
-                                                s: (
-                                                    <li
-                                                        key={`issue-${
-                                                            issue.issue.id
-                                                        }`}
-                                                        className="assembly-issues-panel__list-item assembly-issues-panel__list-item--sm"
-                                                    >
-                                                        <ReportBadge
-                                                            issue={issue.issue}
-                                                            congressman={issue.issue.proponents.reduce(
-                                                                (a, b) => b,
-                                                                undefined
-                                                            )}
-                                                        >
-                                                            {issue.value}
-                                                        </ReportBadge>
-                                                    </li>
-                                                )
-                                            }[issue.issue.type])
-                                    )}
-                                </ul>
-                            </Column>
-                        </Row>
-                    </Grid>
-                </Section>
-
-                <Section>
-                    <Grid>
-                        <Row>
-                            <Column>
-                                <Row>
-                                    <Column>annad stuff</Column>
-                                    <Column>
-                                        <H2>Þessi töludu mest</H2>
-                                        <ul>
-                                            {this.props.speakMost.map(data => (
-                                                <li
-                                                    key={`congressman-speak-${
-                                                        data.congressman.id
-                                                    }`}
-                                                >
-                                                    <Link
-                                                        to={`/loggjafarthing/${
-                                                            this.props.assembly
-                                                                .id
-                                                        }/thingmenn/${
-                                                            data.congressman.id
-                                                        }`}
-                                                    >
-                                                        <Congressman
-                                                            congressman={
-                                                                data.congressman
-                                                            }
-                                                            party={
-                                                                data.congressman
-                                                                    .party
-                                                            }
-                                                        >
-                                                            {data.value}
-                                                        </Congressman>
-                                                    </Link>
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    </Column>
-                                    <Column>
-                                        <H2>Þessi töludu minnst</H2>
-                                        <ul>
-                                            {this.props.speakLeast.map(data => (
-                                                <li
-                                                    key={`congressman-speak-${
-                                                        data.congressman.id
-                                                    }`}
-                                                >
-                                                    <Link
-                                                        to={`/loggjafarthing/${
-                                                            this.props.assembly
-                                                                .id
-                                                        }/thingmenn/${
-                                                            data.congressman.id
-                                                        }`}
-                                                    >
-                                                        <Congressman
-                                                            congressman={
-                                                                data.congressman
-                                                            }
-                                                            party={
-                                                                data.congressman
-                                                                    .party
-                                                            }
-                                                        >
-                                                            {data.value}
-                                                        </Congressman>
-                                                    </Link>
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    </Column>
-                                </Row>
-                            </Column>
-                        </Row>
-                    </Grid>
-                </Section>
-
-                <Section>
-                    <Grid>
-                        <Row>
-                            <Column>
-                                <H2>Þessi spurðu mest</H2>
-                                <ul>
-                                    {this.props.questioner.map(data => (
-                                        <li
-                                            key={`congressman-questioner-${
-                                                data.congressman.id
-                                            }`}
-                                        >
-                                            <Link
-                                                to={`/loggjafarthing/${
-                                                    this.props.assembly.id
-                                                }/thingmenn/${
-                                                    data.congressman.id
-                                                }`}
-                                            >
-                                                <Congressman
-                                                    congressman={
-                                                        data.congressman
-                                                    }
-                                                    party={
-                                                        data.congressman.party
-                                                    }
-                                                >
-                                                    {data.value}
-                                                </Congressman>
-                                            </Link>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </Column>
-                            <Column>
-                                <H2>
-                                    Þessi lögdu fram flestar tillögur til
-                                    þingsályktana
-                                </H2>
-                                <ul>
-                                    {this.props.resolutionaries.map(data => (
-                                        <li
-                                            key={`congressman-resolutionaries-${
-                                                data.congressman.id
-                                            }`}
-                                        >
-                                            <Link
-                                                to={`/loggjafarthing/${
-                                                    this.props.assembly.id
-                                                }/thingmenn/${
-                                                    data.congressman.id
-                                                }`}
-                                            >
-                                                <Congressman
-                                                    congressman={
-                                                        data.congressman
-                                                    }
-                                                    party={
-                                                        data.congressman.party
-                                                    }
-                                                >
-                                                    {data.value}
-                                                </Congressman>
-                                            </Link>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </Column>
-                            <Column>
-                                <H2>
-                                    Þessi lögdu fram flest frumvörp til laga
-                                </H2>
-                                <ul>
-                                    {this.props.bills.map(data => (
-                                        <li
-                                            key={`congressman-bills-${
-                                                data.congressman.id
-                                            }`}
-                                        >
-                                            <Link
-                                                to={`/loggjafarthing/${
-                                                    this.props.assembly.id
-                                                }/thingmenn/${
-                                                    data.congressman.id
-                                                }`}
-                                            >
-                                                <Congressman
-                                                    congressman={
-                                                        data.congressman
-                                                    }
-                                                    party={
-                                                        data.congressman.party
-                                                    }
-                                                >
-                                                    {data.value}
-                                                </Congressman>
-                                            </Link>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </Column>
-                        </Row>
-                    </Grid>
-                </Section>
-
-                <Section>
-                    <Grid>
-                        <Row>
-                            <Column>
-                                <div>
-                                    {this.props.summary.election &&
-                                        this.props.summary.election.title}
-                                </div>
-                                <div>
-                                    {this.props.summary.election &&
-                                        this.props.summary.election.date}
-                                </div>
-                                <div>
-                                    {this.props.summary.election &&
-                                        this.props.summary.election.description}
-                                </div>
-                            </Column>
-                            <Column>
-                                <Row>
-                                    <Column>
-                                        <H2>Úrslit kosninga</H2>
-                                        <PartyPieChart
-                                            formatValue={v => ` ${v}%`}
-                                            source={this.props.summary.electionResults.map(
-                                                item => ({
-                                                    party: item.party,
-                                                    value: item.results.result
-                                                })
-                                            )}
-                                        />
-                                    </Column>
-                                    <Row />
-                                    <Column>
-                                        <H2>Sætaskipan</H2>
-                                        <SeatChart
-                                            source={this.props.summary.electionResults.map(
-                                                item => ({
-                                                    party: item.party,
-                                                    value: item.results.seats
-                                                })
-                                            )}
-                                        />
-                                    </Column>
-                                </Row>
-                            </Column>
-                        </Row>
-                    </Grid>
-                </Section>
-
-                <Section>
-                    <Grid>
-                        <Row>
-                            <Column>
-                                <Paper>
-                                    <Row>
-                                        <Column>
-                                            <h2>Votes</h2>
-                                            <DateAndCountChart
-                                                source={
-                                                    this.props.summary.votes
-                                                }
-                                            />
-                                        </Column>
-                                        <Column>
-                                            <h2>Speeches</h2>
-                                            <DateAndCountChart
-                                                source={
-                                                    this.props.summary.speeches
-                                                }
-                                            />
-                                        </Column>
-                                    </Row>
-                                </Paper>
-                            </Column>
-                        </Row>
-                    </Grid>
                 </Section>
             </Fragment>
         );

--- a/src/client/panels/Assembly/index.scss
+++ b/src/client/panels/Assembly/index.scss
@@ -4,3 +4,57 @@
 .party-pie-chart__path--approved {
     fill: #74bb72;
 }
+
+
+.assembly-page-grid {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    grid-column-gap: 16px;
+    grid-row-gap: 16px;
+    max-width: 1024px;
+    width: 100%;
+    margin: auto;
+}
+
+.assembly-page-grid__header {
+    grid-column: 1 / span 12;
+    grid-row: 1 / 1;
+}
+.assembly-page-grid__types {
+    grid-column: 1 / span 4;
+    grid-row: 2 / 4;
+}
+.assembly-page-grid__speeches {
+    grid-column: 1 / span 4;
+    grid-row: 4 / 8;
+}
+.assembly-page-grid__popular {
+    grid-column: 5 / span 8;
+    grid-row: 2 / 6;
+}
+.assembly-page-grid__talk-max {
+    grid-column: 5 / span 4;
+    grid-row: 6 / 8;
+}
+.assembly-page-grid__talk-min {
+    grid-column: 9 / span 4;
+    grid-row: 6 / 8;
+}
+
+.assembly-page-grid__questions {
+    grid-column: 1 / span 4;
+
+}
+.assembly-page-grid__resolution {
+    grid-column: 5 / span 4;
+}
+.assembly-page-grid__law {
+    grid-column: 9 / span 4;
+}
+
+.assembly-page-grid__election {
+    grid-column: 1 / span 8;
+}
+.assembly-page-grid__seating {
+    grid-column: 9 / span 4;
+}

--- a/src/client/panels/AssemblyCongressman/AssemblyCongressman.tsx
+++ b/src/client/panels/AssemblyCongressman/AssemblyCongressman.tsx
@@ -7,17 +7,15 @@ import { H2 } from "../../elements/Headline";
 import HorizontalChart from "../../elements/HorizontalChart";
 import SessionChart from "../../elements/SessionChart";
 import VoteResultPieChart from "../../elements/VoteResultPieChart";
+import {
+    Person as PersonType,
+    Congressman as CongressmanType
+} from '../../../../@types'
 
 type AssemblyCongressmanProps = {
     assembly?: number,
     congressman?: number,
-    person?: {
-        id?: number,
-        avatar?: {
-            templateSrc?: string
-        },
-        name?: string
-    },
+    person?: PersonType,
     sessions?: {
         id?: number,
         type?: string,
@@ -123,8 +121,7 @@ export default class AssemblyCongressman extends React.Component<AssemblyCongres
                 </Row>
                 <Row>
                     <Column>
-                        {this.props.sessions
-                            .map(session => session.constituency.name)
+                        {this.props.sessions.map(session => session.constituency.name)
                             .reduce((total, item) => {
                                 if (total.indexOf(item) < 0) {
                                     total.push(item);

--- a/src/client/panels/AssemblyCongressmen/AssemblyCongressmen.tsx
+++ b/src/client/panels/AssemblyCongressmen/AssemblyCongressmen.tsx
@@ -2,38 +2,15 @@ import * as React from "react";
 import { Link } from "react-router-dom";
 import { Column, Row } from "../../elements/Grid";
 import Congressman from "../../elements/Congressman";
+import {
+    Congressman as CongressmanType,
+    Assembly as AssemblyType
+} from '../../../../@types';
+
 type AssemblyCongressmenProps = {
     assembly?: number,
-    congressmen?: {
-        id?: number,
-        name?: string,
-        avatar?: {
-            templateSrc?: string
-        },
-        party?: {
-            id?: number,
-            name?: string,
-            color?: string
-        },
-        assembly?: {
-            id?: number
-        }
-    }[],
-    substitutes?: {
-        id?: number,
-        name?: string,
-        avatar?: {
-            templateSrc?: string
-        },
-        party?: {
-            id?: number,
-            name?: string,
-            color?: string
-        },
-        assembly?: {
-            id?: number
-        }
-    }[]
+    congressmen: CongressmanType[],
+    substitutes: (CongressmanType & {assembly: AssemblyType})[]
 };
 export default class AssemblyCongressmen extends React.Component<
     AssemblyCongressmenProps,

--- a/src/client/panels/AssemblyIssue/AssemblyIssue.tsx
+++ b/src/client/panels/AssemblyIssue/AssemblyIssue.tsx
@@ -6,13 +6,15 @@ import DateAndCountChart from "../../elements/DateAndCountChart";
 import * as Markdown from "react-markdown";
 import { H2, H4 } from "../../elements/Headline";
 import Paper from "../../elements/Paper";
+import {
+    Congressman as CongressmanType,
+    Assembly as AssemblyType
+} from '../../../../@types';
 
 type AssemblyIssueProps = {
     issue?: {
         id?: number,
-        assembly?: {
-            id?: number
-        },
+        assembly: AssemblyType,
         name?: string,
         status?: string,
         goal?: string,
@@ -27,31 +29,9 @@ type AssemblyIssueProps = {
         deliveries?: string,
         additionalInformation?: string,
         date?: string,
-        proponents?: {
-            id?: number,
-            name?: string,
-            avatar?: {
-                templateSrc?: string
-            },
-            party?: {
-                id?: number,
-                name?: string,
-                color?: string
-            }
-        }[],
+        proponents: CongressmanType[],
         speakers?: {
-            congressman?: {
-                id?: number,
-                name?: string,
-                avatar?: {
-                    templateSrc?: string
-                },
-                party?: {
-                    id?: number,
-                    name?: string,
-                    color?: string
-                }
-            },
+            congressman: CongressmanType,
             value?: number
         }[],
         voteRange?: {

--- a/src/client/panels/AssemblyIssues/AssemblyIssues.tsx
+++ b/src/client/panels/AssemblyIssues/AssemblyIssues.tsx
@@ -14,32 +14,20 @@ import {
     RequestForReportBadge,
     WrittenInquiryBadge
 } from "../../elements/IssueBadge";
+import {Congressman as CongressmanType, Assembly as AssemblyType} from '../../../../@types'
 import './index.scss';
 
 type AssemblyIssuesProps = {
     issues?: {
         id?: number,
-        assembly?: {
-            id?: number
-        },
+        assembly: AssemblyType,
         name?: string,
         status?: string,
         type?: string,
         goal?: string,
         typeName?: string,
         proponentsCount?: number,
-        proponents?: {
-            id?: number,
-            name?: string,
-            avatar?: {
-                templateSrc?: string
-            },
-            party?: {
-                id?: number,
-                name?: string,
-                color?: string
-            }
-        }[]
+        proponents: CongressmanType[]
     }[],
     assembly?: number,
     done?: boolean,

--- a/src/client/panels/AssemblyIssues/index.scss
+++ b/src/client/panels/AssemblyIssues/index.scss
@@ -10,8 +10,8 @@
     grid-template-columns: 1fr;
     grid-template-rows: 1fr 1fr;
 
-    grid-column-gap: map_get($space, lg);
-    grid-row-gap: map_get($space, lg);
+    grid-column-gap: map_get($space, md);
+    grid-row-gap: map_get($space, md);
 
     grid-auto-flow: dense;
 

--- a/src/client/panels/IssueDocuments/IssueDocuments.tsx
+++ b/src/client/panels/IssueDocuments/IssueDocuments.tsx
@@ -3,6 +3,7 @@ import { Row, Column } from "../../elements/Grid";
 import Congressman from "../../elements/Congressman";
 import VoteResultPieChart from "../../elements/VoteResultPieChart";
 import DocumentCongressmanVotes from "../../components/DocumentCongressmanVotes";
+import {Congressman as CongressmanType} from "../../../../@types";
 
 type IssueDocumentsProps = {
     assembly?: number,
@@ -12,18 +13,7 @@ type IssueDocumentsProps = {
         url?: string,
         date?: string,
         type?: string,
-        proponents?: {
-            id?: number,
-            name?: string,
-            avatar?: {
-                templateSrc?: string
-            },
-            party?: {
-                id?: number,
-                name?: string,
-                color?: string
-            }
-        }[],
+        proponents: CongressmanType[],
         votes?: {
             id?: number,
             type?: string,

--- a/src/client/panels/IssueSpeeches/IssueSpeeches.tsx
+++ b/src/client/panels/IssueSpeeches/IssueSpeeches.tsx
@@ -7,6 +7,7 @@ import Loading from "../../elements/Loading/index";
 import { H4 } from "../../elements/Headline";
 import SpeechCard from "../../elements/SpeechCard";
 import ScrollIntoView from "../../elements/ScrollIntoView";
+import {Congressman as CongressmanType} from '../../../../@types';
 
 type IssueSpeechesProps = {
     assembly?: number,
@@ -28,18 +29,7 @@ type IssueSpeechesProps = {
         iteration?: string,
         type?: string,
         congressmanType?: string,
-        congressman?: {
-            id?: number,
-            name?: string,
-            avatar?: {
-                templateSrc?: string
-            },
-            party?: {
-                id?: number,
-                name?: string,
-                color?: string
-            }
-        }
+        congressman: CongressmanType
     }[],
     done?: boolean,
     loadMore?: (...args: any[]) => any,

--- a/src/client/utils/bills.ts
+++ b/src/client/utils/bills.ts
@@ -1,7 +1,9 @@
 
-export const reduceBillsByStatus = (bills: {count: number, status: string}[]): {unapproved?: number, approved?: number} => {
+export const reduceBillsByStatus = (
+    bills: Array<{count: number, status: string}>,
+): {unapproved?: number, approved?: number} => {
     return bills.reduce((accumulator, currentValue) => {
-        if (currentValue.status === "Samþykkt sem lög frá Alþingi") {
+        if (currentValue.status === 'Samþykkt sem lög frá Alþingi') {
             accumulator.approved = currentValue.count;
         } else {
             accumulator.unapproved = accumulator.unapproved + currentValue.count;
@@ -14,19 +16,19 @@ export const billsPerformance = (value: {unapproved?: number, approved?: number}
     return Math.round((value.approved / (value.unapproved + value.approved)) * 100) || 0;
 };
 
-
-export const mapBillStatusToKey = (bill: {count: number, status: string}): {count: number, key: string, label: string} => {
+export const mapBillStatusToKey = (
+    bill: {count: number, status: string},
+): {count: number, key: string, label: string} => {
     const map = {
-        "Bíður 1. umræðu": 'iteration-one',
-        "Bíður 2. umræðu": 'iteration-two',
-        "Í nefnd eftir 1. umræðu": 'committee-one',
-        "Í nefnd eftir 2. umræðu": 'committee-two',
-        "Samþykkt sem lög frá Alþingi": 'approved',
-        undefined: 'unapproved'
+        'Bíður 1. umræðu': 'iteration-one',
+        'Bíður 2. umræðu': 'iteration-two',
+        'Í nefnd eftir 1. umræðu': 'committee-one',
+        'Í nefnd eftir 2. umræðu': 'committee-two',
+        'Samþykkt sem lög frá Alþingi': 'approved',
     };
     return {
         count: bill.count,
-        key: String(map[bill.status]),
-        label: bill.status
-    }
+        key: String(map[bill.status] || 'unapproved'),
+        label: bill.status,
+    };
 };

--- a/src/client/utils/bills.ts
+++ b/src/client/utils/bills.ts
@@ -1,0 +1,32 @@
+
+export const reduceBillsByStatus = (bills: {count: number, status: string}[]): {unapproved?: number, approved?: number} => {
+    return bills.reduce((accumulator, currentValue) => {
+        if (currentValue.status === "Samþykkt sem lög frá Alþingi") {
+            accumulator.approved = currentValue.count;
+        } else {
+            accumulator.unapproved = accumulator.unapproved + currentValue.count;
+        }
+        return accumulator;
+    }, {unapproved: 0, approved: 0});
+};
+
+export const billsPerformance = (value: {unapproved?: number, approved?: number}): number => {
+    return Math.round((value.approved / (value.unapproved + value.approved)) * 100) || 0;
+};
+
+
+export const mapBillStatusToKey = (bill: {count: number, status: string}): {count: number, key: string, label: string} => {
+    const map = {
+        "Bíður 1. umræðu": 'iteration-one',
+        "Bíður 2. umræðu": 'iteration-two',
+        "Í nefnd eftir 1. umræðu": 'committee-one',
+        "Í nefnd eftir 2. umræðu": 'committee-two',
+        "Samþykkt sem lög frá Alþingi": 'approved',
+        undefined: 'unapproved'
+    };
+    return {
+        count: bill.count,
+        key: String(map[bill.status]),
+        label: bill.status
+    }
+};

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -42,9 +42,9 @@ app.get('*', (request, response) => {
 
     response.send(`
              <!doctype html>
-             <html>
+             <html lang="is">
                  <head>
-                     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+                     <meta name="viewport" content="width=device-width, initial-scale=1">
                      <link rel="stylesheet" type="text/css" href="${assetsServer}/stylesheets/application.css" />
                  </head>
                  <body>
@@ -89,7 +89,7 @@ app.get('*', (request, response) => {
         const html = `<!doctype html>
              <html lang="is">
                  <head>
-                     <meta name="viewport" content="width=device-width, initial-scale=2">
+                     <meta name="viewport" content="width=device-width, initial-scale=1">
                      <meta property="og:site_name" content="Löggjafarþing">
                      <link rel="stylesheet" type="text/css" href="${assetsServer}/stylesheets/application.css" />
                      ${helmet.title.toString()}
@@ -111,7 +111,7 @@ app.get('*', (request, response) => {
     }).catch(error => {
 
         const html = ReactDOM.renderToStaticMarkup(
-            <html>
+            <html lang="is">
                 <head>
                     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
                     <link rel="stylesheet" type="text/css" href="/stylesheets/application.css" />

--- a/src/server/types/AssemblySummary.ts
+++ b/src/server/types/AssemblySummary.ts
@@ -2,7 +2,7 @@ import {GraphQLObjectType, GraphQLInt, GraphQLList, GraphQLString, GraphQLFloat}
 import Party from './Party';
 
 export default new GraphQLObjectType({
-    name: 'AssemblySummary',
+    name: 'AssemblyStatistics',
     fields: {
         bills: {
             type: new GraphQLList(new GraphQLObjectType({

--- a/src/server/types/Congressman.ts
+++ b/src/server/types/Congressman.ts
@@ -28,13 +28,8 @@ export default new GraphQLObjectType({
                 return {
                     src: `http://www.althingi.is/myndir/mynd/thingmenn/${root.congressman_id}/org/mynd.jpg`,
                     templateSrc: process.env.IMAGE_SERVER
-                        ? `${process.env.IMAGE_SERVER}/unsafe/{size}/smart/https://www.althingi.is/myndir/mynd/thingmenn/${root.congressman_id}/org/mynd.jpg`
+                        ? `${process.env.IMAGE_SERVER}/unsafe/{size}/smart/https://www.althingi.is/myndir/mynd/thingmenn/${root.congressman_id}/org/mynd.jpg` // tslint:disable-line
                         : `https://www.althingi.is/myndir/mynd/thingmenn/${root.congressman_id}/org/mynd.jpg`,
-                    //
-                    // templateSrc: process.env.IMAGE_SERVER
-                    //     ?  `${process.env.IMAGE_SERVER}/unsafe/{size}/smart/https://www.althingi.is/myndir/thingmenn-cache/${root.congressman_id}/${root.congressman_id}-220.jpg`
-                    //     : `https://www.althingi.is/myndir/thingmenn-cache/${root.congressman_id}/${root.congressman_id}-220.jpg`,
-                    // // https://www.althingi.is/myndir/mynd/thingmenn/1324/org/mynd.jpg
                 };
             },
         },

--- a/src/server/types/Person.ts
+++ b/src/server/types/Person.ts
@@ -24,9 +24,8 @@ export default new GraphQLObjectType({
                 return {
                     src: `http://www.althingi.is/myndir/mynd/thingmenn/${root.congressman_id}/org/mynd.jpg`,
                     templateSrc: process.env.IMAGE_SERVER
-                        ?  `${process.env.IMAGE_SERVER}/unsafe/{size}/smart/https://www.althingi.is/myndir/thingmenn-cache/${root.congressman_id}/${root.congressman_id}-220.jpg`
-                        : `https://www.althingi.is/myndir/thingmenn-cache/${root.congressman_id}/${root.congressman_id}-220.jpg`,
-                    // https://www.althingi.is/myndir/mynd/thingmenn/1324/org/mynd.jpg
+                        ? `${process.env.IMAGE_SERVER}/unsafe/{size}/smart/https://www.althingi.is/myndir/mynd/thingmenn/${root.congressman_id}/org/mynd.jpg` // tslint:disable-line
+                        : `https://www.althingi.is/myndir/mynd/thingmenn/${root.congressman_id}/org/mynd.jpg`,
                 };
             },
         },


### PR DESCRIPTION
## What?
Assembly summary page in `display: grid` as described here: https://github.com/fizk/Loggjafarthing/issues/27

## How?
Use css `grid` do build a better display

## Why?
So it looks better